### PR TITLE
feat: support HAML comment (-#) conversion to ERB

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,11 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
         env:
           HAML_VERSION: ${{ matrix.haml-version }}
       - name: Run tests
         run: bundle exec rspec
+        env:
+          HAML_VERSION: ${{ matrix.haml-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,6 @@ jobs:
       matrix:
         ruby-version: ["3.2", "3.3", "3.4"]
         haml-version: ["~> 5.0", "~> 6.0", "~> 7.0"]
-        exclude:
-          # Haml 7.x requires Ruby 3.2+, but exclude older Ruby just to reduce matrix
-          # All combinations are valid since we require Ruby 3.2+
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/lib/haml_to_erb/converter.rb
+++ b/lib/haml_to_erb/converter.rb
@@ -35,7 +35,7 @@ module HamlToErb
       when :doctype      then emit_doctype(node, depth)
       when :comment      then emit_comment(node, depth)
       when :plain        then emit_plain(node, depth)
-      when :haml_comment then ""
+      when :haml_comment then emit_haml_comment(node, depth)
       else
         warn "Unknown node type: #{node.type}"
         ""
@@ -162,6 +162,15 @@ module HamlToErb
 
     def emit_comment(node, depth)
       "#{indent(depth)}<!-- #{node.value[:text]} -->\n"
+    end
+
+    def emit_haml_comment(node, depth)
+      text = node.value[:text]
+      if text.include?("\n")
+        "#{indent(depth)}<%#\n#{text.lines.map { |l| "#{indent(depth + 1)}#{l}" }.join}#{indent(depth)}%>\n"
+      else
+        "#{indent(depth)}<%##{text} %>\n"
+      end
     end
 
     def emit_plain(node, depth)

--- a/spec/haml_to_erb/converter_spec.rb
+++ b/spec/haml_to_erb/converter_spec.rb
@@ -363,10 +363,35 @@ RSpec.describe HamlToErb::Converter do
         expect(result).to include("<!-- This is a comment -->")
       end
 
-      it "omits HAML comments from output" do
-        result = convert("-# This is a HAML comment")
-        expect(result).not_to include("HAML comment")
-        expect(result).not_to include("<!--")
+      it "converts HAML comments to ERB comments" do
+        result = convert("-# This is a HAML comment\n-# 2nd line")
+        expect(result.strip).to eq("<%# This is a HAML comment %>\n<%# 2nd line %>")
+      end
+
+      it "converts multi-line HAML comments" do
+        haml = <<~HAML
+          -#
+            Line 1
+            Line 2
+        HAML
+        result = convert(haml)
+        expect(result.strip).to eq(<<~EOS.strip)
+          <%#
+            Line 1
+            Line 2
+          %>
+        EOS
+      end
+
+      it "preserves indentation for nested comments" do
+        haml = <<~HAML
+          %div
+            -# nested
+            %p text
+        HAML
+        result = convert(haml)
+        expect(result).to include("  <%# nested %>")
+        expect(result).to include("  <p>text</p>")
       end
     end
 


### PR DESCRIPTION
## Summary
This PR implements the conversion of HAML comments (`-#`) into ERB comments (`<%# ... %>`). Previously, HAML comments were silently discarded during the conversion process. This change ensures that internal comments are preserved in the resulting ERB templates.
## Reproduction
To see the current behavior (discarding comments), run the converter with a file containing `-#`:
```haml
-# Single line comment
%div
  -#
    Multi-line
    comment
```
## Actual Behavior (Before)
HAML comments were ignored, and no corresponding code was generated in the ERB output:
```erb
<div>
</div>
```
## Expected Behavior (After)
HAML comments are converted to ERB comments, preserving their content and multi-line structure:
```erb
<%# Single line comment %>
<div>
  <%#
    Multi-line
    comment
  %>
</div>
```