### PR TITLE
ci: fix test matrix (empty exclude block + HAML_VERSION with bundler-cache)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,11 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
         env:
           HAML_VERSION: ${{ matrix.haml-version }}
       - name: Run tests
         run: bundle exec rspec
+        env:
+          HAML_VERSION: ${{ matrix.haml-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,6 @@ jobs:
       matrix:
         ruby-version: ["3.2", "3.3", "3.4"]
         haml-version: ["~> 5.0", "~> 6.0", "~> 7.0"]
-        exclude:
-          # Haml 7.x requires Ruby 3.2+, but exclude older Ruby just to reduce matrix
-          # All combinations are valid since we require Ruby 3.2+
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby


### PR DESCRIPTION
## Summary

Two small fixes to the GitHub Actions CI workflow that caused the Haml version matrix to fail:

- **Remove empty `exclude:` block** — An empty `exclude:` list under the matrix causes a workflow parse error. Removed the block entirely since all Ruby/Haml version combinations are valid (the gem requires Ruby 3.2+ which covers all three Haml versions).
- **Fix `bundle install` with `HAML_VERSION` env var** — `bundler-cache: true` runs Bundler in deployment/frozen mode, which rejects runtime gem additions via `ENV`. Replaced it with an explicit `bundle install` step that has `HAML_VERSION` in scope, so the lockfile can be updated at runtime. Also added the same `env:` block to the test step so `HAML_VERSION` is available when the specs run.

## Changes

`.github/workflows/main.yml` only — no library or test code changed.