### PR TITLE
fix: preserve attributes when a quoted key contains a colon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,11 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
         env:
           HAML_VERSION: ${{ matrix.haml-version }}
       - name: Run tests
         run: bundle exec rspec
+        env:
+          HAML_VERSION: ${{ matrix.haml-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,6 @@ jobs:
       matrix:
         ruby-version: ["3.2", "3.3", "3.4"]
         haml-version: ["~> 5.0", "~> 6.0", "~> 7.0"]
-        exclude:
-          # Haml 7.x requires Ruby 3.2+, but exclude older Ruby just to reduce matrix
-          # All combinations are valid since we require Ruby 3.2+
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/lib/haml_to_erb/attribute_builder.rb
+++ b/lib/haml_to_erb/attribute_builder.rb
@@ -16,6 +16,12 @@ module HamlToErb
       required reversed scoped seamless selected
     ].freeze
 
+    # Matches one "key =>" or "key:" pair at the start of a Ruby hash body.
+    # The key may be a symbol (:foo), a quoted string ("v-bind:x"), or a bare
+    # word (foo). Quoted keys allow any inner character so attribute names with
+    # colons, dots, @, etc. (Vue/Angular/Stimulus bindings) parse correctly.
+    KEY_PATTERN = /\A\s*(?::(\w+)|(['"])((?:\\.|[^\\])*?)\2|([\w-]+))\s*(?:=>|:)\s*/
+
     def initialize
       @parser = PrismParser.new
     end
@@ -158,7 +164,7 @@ module HamlToErb
         end
 
         # Match key: symbol (:foo), string ('foo'/"foo"), or bare word (foo)
-        match = remaining.match(/\A\s*(?::(\w+)|(['"])([\w-]+)\2|([\w-]+))\s*(?:=>|:)\s*/)
+        match = remaining.match(KEY_PATTERN)
         break unless match
 
         key = (match[1] || match[3] || match[4]).tr("_", "-")
@@ -275,7 +281,7 @@ module HamlToErb
       remaining = content.strip
 
       while remaining && !remaining.empty?
-        match = remaining.match(/\A\s*(?::(\w+)|(['"])([\w-]+)\2|([\w-]+))\s*(?:=>|:)\s*/)
+        match = remaining.match(KEY_PATTERN)
         break unless match
 
         raw_key = (match[1] || match[3] || match[4]).tr("_", "-")

--- a/spec/haml_to_erb/attribute_builder_spec.rb
+++ b/spec/haml_to_erb/attribute_builder_spec.rb
@@ -176,6 +176,30 @@ RSpec.describe HamlToErb::AttributeBuilder do
       end
     end
 
+    context "quoted keys containing colons (framework bindings)" do
+      it "keeps a colon-containing string key with a dynamic value" do
+        result = build_dynamic('"v-bind:x" => foo')
+        expect(result).to eq(' v-bind:x="<%= foo %>"')
+      end
+
+      it "keeps a colon-containing string key with a string value" do
+        result = build_dynamic('"v-bind:x" => "y"')
+        expect(result).to eq(' v-bind:x="y"')
+      end
+
+      it "does not drop sibling attributes when a colon key has a dynamic value" do
+        result = build_dynamic('"v-bind:x" => foo, "class" => "c"')
+        expect(result).to include('class="c"')
+        expect(result).to include('v-bind:x="<%= foo %>"')
+      end
+
+      it "handles Vue/Angular shorthand binding keys" do
+        result = build_dynamic('"@click" => handler, ":value" => model')
+        expect(result).to include('@click="<%= handler %>"')
+        expect(result).to include(':value="<%= model %>"')
+      end
+    end
+
     context "array values" do
       it "joins array class values with spaces" do
         result = build_dynamic('class: ["foo", "bar", "baz"]')


### PR DESCRIPTION
## Problem

When a dynamic attribute hash has a key that is a **quoted string containing a colon** (e.g. `"v-bind:x"`) and a **non-literal (expression) value**, the conversion **silently drops the entire attribute hash** — including unrelated sibling attributes.

```ruby
HamlToErb.convert(%q{%div{"v-bind:x" => foo}})
# expected: <div v-bind:x="<%= foo %>"></div>
# actual:   <div></div>
```

Sibling attributes are collateral damage:

```ruby
HamlToErb.convert(%q{%div{"v-bind:x" => foo, "class" => "c"}})
# actual: <div></div>   (class="c" is lost too)
```

## Why it happened

The bug only triggers on the **dynamic-value fallback path**. With a string-literal value, Prism parses the hash statically and never reaches it; with an expression value, Prism returns `nil` and `parse_to_erb_attrs` runs.

There, the key-matching regex restricted quoted keys to `[\w-]+`, so a colon inside `"v-bind:x"` failed to match. The parse loop then `break`s before emitting any attribute, discarding the whole hash.

## Fix

- Allow any inner character in quoted keys so framework binding keys (Vue/Angular/Stimulus: `v-bind:x`, `@click`, `:value`, `v-on:click.prevent`) parse correctly.
- Extract the duplicated key pattern into a single `KEY_PATTERN` constant (it appeared identically in two places) so both the top-level and nested-hash parsers stay in sync.

## Tests

Added regression specs covering colon-containing keys with dynamic/literal values, sibling-attribute preservation, and Vue/Angular shorthand bindings. Full suite green.

---

> **Draft note:** Also includes two CI fixes (empty `exclude:` block and `HAML_VERSION` env var not being picked up by `bundler-cache: true`) that were needed to get the matrix builds green. Keeping as draft until #3 is reviewed/merged so changes land in a clean order.